### PR TITLE
Add std.core/future-loop

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.framed/std "0.1.1"
+(defproject io.framed/std "0.1.2"
   :description "A Clojure utility toolkit"
   :url "https://github.com/framed-data/std"
   :license {:name "MIT License"

--- a/src/framed/std/core.clj
+++ b/src/framed/std/core.clj
@@ -96,8 +96,10 @@
   (if (sequential? x-or-xs) x-or-xs [x-or-xs]))
 
 (defn flip
-  "Takes two arguments in the reverse order of f ('flips' a function of two arguments)
-   If supplied a function with no args, returns a new function accepting the reversed args
+  "Takes two arguments in the reverse order of f ('flips' a function
+   of two arguments)
+   If supplied a function with no args, returns a new function
+   accepting the reversed args
 
    Ex:
      (flip dissoc :foo {:foo 1 :bar 2})
@@ -110,3 +112,11 @@
    (fn [y x] (f x y)))
   ([f y x]
    (f x y)))
+
+(defmacro future-loop
+  "Execute body repeatedly within a future, returning the future"
+  [& body]
+  `(future
+     (loop []
+       ~@body
+       (recur))))


### PR DESCRIPTION
A useful helper for repeatedly executing a body expression in a separate
thread.

Ex:

``` clj
(def f (future-loop
         (println "Hello")
         (Thread/sleep 1000)))
; #'f
; => "Hello"
; => "Hello"
; ...
(future-cancel f)
; => true
```
