### PR TITLE
io/move: Return dest as-is and clarify docs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.framed/std "0.1.2"
+(defproject io.framed/std "0.1.3"
   :description "A Clojure utility toolkit"
   :url "https://github.com/framed-data/std"
   :license {:name "MIT License"

--- a/src/framed/std/io.clj
+++ b/src/framed/std/io.clj
@@ -73,11 +73,11 @@
   (io/file link))
 
 (defn move
-  "Atomically move file-like src to file-like dest
+  "Atomically move file-like src to file-like dest and return dest.
    Throws error if dest already exists"
   [src dest]
   (if (.exists (io/file dest))
     (throw (IllegalArgumentException. "dest already exists"))
     (let [copy-opts (into-array [StandardCopyOption/ATOMIC_MOVE])]
       (Files/move (->Path src) (->Path dest) copy-opts)
-      (io/file dest))))
+      dest)))


### PR DESCRIPTION
Returning `dest` as-is (as opposed to coercing with `io/file` seems more
consistent with `std.io/spit` and other libraries in general) - gives
more flexibility to callers.
