### PR TITLE
Refactorings/additions for 0.1.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.framed/std "0.1.3"
+(defproject io.framed/std "0.1.4"
   :description "A Clojure utility toolkit"
   :url "https://github.com/framed-data/std"
   :license {:name "MIT License"

--- a/src/framed/std/io.clj
+++ b/src/framed/std/io.clj
@@ -1,26 +1,24 @@
 (ns framed.std.io
   "I/O utility functions to complement clojure.java.io"
   (:require [clojure.java.io :as io])
-  (:import (java.io File DataInputStream DataOutputStream)
+  (:import (java.io Closeable File DataInputStream DataOutputStream)
            (org.apache.commons.io IOUtils)
            (java.nio.file Files StandardCopyOption))
   (:refer-clojure :exclude [spit]))
 
-(def ^:no-doc tmpdir (System/getProperty "java.io.tmpdir"))
+(def tmpdir
+  "The system temporary directory"
+  (System/getProperty "java.io.tmpdir"))
 
 (defn data-input-stream
   "Coerce argument to an open java.io.DataInputStream"
   [istream-like]
-  (-> istream-like
-      (io/input-stream)
-      (DataInputStream.)))
+  (DataInputStream. (io/input-stream istream-like)))
 
 (defn data-output-stream
   "Coerce argument to an open java.io.DataOutputStream"
   [ostream-like]
-  (-> ostream-like
-      (io/output-stream)
-      (DataOutputStream.)))
+  (DataOutputStream. (io/output-stream ostream-like)))
 
 (defn stream-copy
   "Copy from input stream to output stream.
@@ -67,10 +65,10 @@
 
 (defn create-link
   "Create a hard-link for file-like link to file-like existing
-   Returns a File reference to the link"
+   Returns link"
   [link existing]
   (Files/createLink (->Path link) (->Path existing))
-  (io/file link))
+  link)
 
 (defn move
   "Atomically move file-like src to file-like dest and return dest.
@@ -81,3 +79,9 @@
     (let [copy-opts (into-array [StandardCopyOption/ATOMIC_MOVE])]
       (Files/move (->Path src) (->Path dest) copy-opts)
       dest)))
+
+(defn close
+  "Close the given java.io.Closeable and return nil"
+  [^Closeable x]
+  (.close x)
+  nil)

--- a/test/framed/std/serialization_test.clj
+++ b/test/framed/std/serialization_test.clj
@@ -28,6 +28,19 @@
   (prop/for-all [vs (gen/vector gen/simple-type-printable)]
     (= (seq (coll->FressianSeq vs)) (seq vs))))
 
+(deftest test-read-csv
+  (let [f (std.io/tempfile)]
+    (write-csv f
+               ["name","age"]
+               [["John" 27]
+                ["Mary" 28]])
+    (is (= [["name","age"] ["John" "27"] ["Mary" "28"]]
+           (read-csv f))
+        "It reads labels and rows")
+    (is (= [["John" "27"] ["Mary" "28"]]
+           (read-csv true f))
+        "It drops headers")))
+
 (deftest test-write-csv
   (let [w (java.io.StringWriter.)]
     (write-csv w


### PR DESCRIPTION
Changes:

std.io
- `tmpdir` is now public and documented
- Add `close`
- `create-link` now returns link unmodified (instead of coercing with `io/file`),
  to be more consistent with other functions

std.serialization
- Extract `closing-seq` (similar to old `seq<-auto` construct) and
  `consume-with`, which DRYs up reader code and fixes handle leak in
  read-csv
- Fix handle leak in `read-transit`
- Add `read-jsonl` for JSON Lines
- Type-hint read-avro'
- Add tests for read/write CSV
