### PR TITLE
0.1.5 - Add core/shuffle

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.framed/std "0.1.4"
+(defproject io.framed/std "0.1.5"
   :description "A Clojure utility toolkit"
   :url "https://github.com/framed-data/std"
   :license {:name "MIT License"

--- a/src/framed/std/core.clj
+++ b/src/framed/std/core.clj
@@ -1,6 +1,6 @@
 (ns framed.std.core
   "Utility functions to complement clojure.core"
-  (:refer-clojure :exclude [mapcat]))
+  (:refer-clojure :exclude [mapcat shuffle]))
 
 (defn mapcat
   "Like clojure.core/mapcat over a single coll without object
@@ -15,6 +15,14 @@
     (when (seq coll)
       (concat (f (first coll))
               (mapcat f (rest coll))))))
+
+(defn shuffle
+  "Same as clojure.core/shuffle but accepts source of randomness
+   for deterministic testing"
+  [^java.util.Random rng ^java.util.Collection coll]
+  (let [al (java.util.ArrayList. coll)]
+    (java.util.Collections/shuffle al rng)
+    (clojure.lang.RT/vector (.toArray al))))
 
 (defmacro map-from-keys
   "Given symbols, e.g. `(map-from-keys foo bar)`,

--- a/test/framed/std/core_test.clj
+++ b/test/framed/std/core_test.clj
@@ -11,6 +11,11 @@
     (is (= (clojure.core/mapcat identity vs) (s/mapcat identity vs)))
     (is (= (clojure.core/mapcat seq vs) (s/mapcat seq vs)))))
 
+(deftest test-shuffle
+  (let [rng (java.util.Random. 1)]
+    (is (= [7 10 8 9 5 3 1 4 2 6]
+           (s/shuffle (java.util.Random. 1) [1 2 3 4 5 6 7 8 9 10])))))
+
 (deftest test-map-from-keys
   (let [foo 1
         bar 2]


### PR DESCRIPTION
This is the same as clojure.core/shuffle, but accepts a `java.util.Random`
for repeatable results / deterministic testing