### PR TITLE
std.time/period-interval: Require period

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.framed/std "0.1.6"
+(defproject io.framed/std "0.1.7"
   :description "A Clojure utility toolkit"
   :url "https://github.com/framed-data/std"
   :license {:name "Eclipse Public License"
@@ -17,6 +17,4 @@
                  [org.clojure/test.check "0.8.0"]]
   :plugins [[codox "0.8.13"]
             [lein-cljsbuild "1.0.6"]]
-  :cljsbuild {:builds []}
-  ;:codox {:src-dir-uri "http://github.com/framed-data/std/tree/master"}
-  )
+  :cljsbuild {:builds []})

--- a/src/framed/std/time.clj
+++ b/src/framed/std/time.clj
@@ -55,7 +55,7 @@
   ([date period n]
    (period-interval date period n (inc n)))
   ([date period n0 n1]
-   {:pre [(< n0 n1)]}
+   {:pre [date period n0 n1 (< n0 n1)]}
    (tcore/interval
      (periods-from date period n0)
      (periods-from date period n1))))

--- a/test/framed/std/time_test.clj
+++ b/test/framed/std/time_test.clj
@@ -32,6 +32,8 @@
       "It calculates multiple periods forward correctly."))
 
 (deftest test-period-interval
+  (is (thrown? AssertionError
+               (std.time/period-interval (tcore/date-time 2015 1 1) nil -1 0)))
   (is (= (tcore/interval
            (tcore/date-time 2014 11 6)
            (tcore/date-time 2014 11 13))


### PR DESCRIPTION
This can lead to very strange behavior if the period is nil:

```clj
(std.time/period-interval (tcore/date-time 2015 6 22) nil -1)
; => <Interval 2015-06-22 : 2015-06-22>
```

This doesn't seem useful, so require the period to be present.