### PR TITLE
Add write-jsonl

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.framed/std "0.1.7"
+(defproject io.framed/std "0.1.8"
   :description "A Clojure utility toolkit"
   :url "https://github.com/framed-data/std"
   :license {:name "Eclipse Public License"

--- a/src/framed/std/serialization.clj
+++ b/src/framed/std/serialization.clj
@@ -94,6 +94,15 @@
   (spit writer-like (json/generate-string data))
   writer-like)
 
+(defn write-jsonl
+  "Write arbitrary data as JSONL to writer-like and return writer-like"
+  [writer-like coll]
+  (with-open [w (io/writer writer-like)]
+    (doseq [x coll]
+      (json/generate-to-writer x w)
+      (.write w "\n")))
+  writer-like)
+
 ;;
 
 (def default-transit-encoding

--- a/test/framed/std/serialization_test.clj
+++ b/test/framed/std/serialization_test.clj
@@ -67,6 +67,15 @@
            "0.333,0.14\n3.1415,0.492\n")
         "It writes decimals")))
 
+(deftest test-write-jsonl
+  (let [coll [{:foo :bar}
+              {:baz :quux}]
+        tempfile (std.io/tempfile)
+        result (write-jsonl tempfile coll)]
+    (is (= (read-jsonl tempfile)
+           [{"foo" "bar"}
+            {"baz" "quux"}]))))
+
 (deftest test-file->NippySeq
   (let [colls [[1 2] [3 4] [5 6]]
         paths (map (fn [_] (std.io/tempfile)) colls)]


### PR DESCRIPTION
This commit adds a basic function to write JSONL to a file.
This is useful because many analytics services' data comes in JSONL.