### PR TITLE
std 0.1.8

### DIFF
--- a/src/framed/std/core.cljc
+++ b/src/framed/std/core.cljc
@@ -1,5 +1,7 @@
 (ns framed.std.core
   "Utility functions to complement clojure.core"
+  (:require #?(:clj [clojure.edn]
+               :cljs [cljs.reader]))
   (:refer-clojure :exclude [mapcat shuffle]))
 
 (defn mapcat
@@ -19,7 +21,7 @@
 #?(:clj
   (defn shuffle
     "Same as clojure.core/shuffle but accepts source of randomness
-    for deterministic testing"
+     for deterministic testing"
     [^java.util.Random rng ^java.util.Collection coll]
     (let [al (java.util.ArrayList. coll)]
       (java.util.Collections/shuffle al rng)
@@ -85,19 +87,26 @@
           [(key-fn k) (val-fn v)])
         coll)))
 
-(def map-kv
-  "Same as `map-tup` but returns results in a map"
+(def
+  ^{:doc "Same as `map-tup` but returns results in a map"
+    :arglists '([val-fn coll] [key-fn val-fn coll])}
+  map-kv
   (comp (partial into {}) map-tup))
 
 (defn when-assoc-in
- "When v is truthy, assoc it into coll. Otherwise just return coll"
+ "When v is truthy, assoc it into coll at ks. Otherwise return coll"
   [coll ks v]
-  (if-not v
-    coll
-    (assoc-in coll ks v)))
+  (if v
+    (assoc-in coll ks v)
+    coll))
+
+(defn when-assoc
+ "When v is truthy, assoc it into coll at k. Otherwise return coll"
+  [coll k v]
+  (when-assoc-in coll [k] v))
 
 (defn coll-wrap
-  "Wrap value in a vector if it is not coll-like already
+  "Wrap value in a vector if it is not sequential already
    Ex:
      (coll-wrap 2)       ; => [2]
      (coll-wrap [1 2 3]) ; => [1 2 3]"
@@ -130,3 +139,15 @@
        (loop []
          ~@body
          (recur)))))
+
+(defn try-to-edn
+  "pr-str x only if it is truthy, else return nil"
+  [x]
+  (when x
+    (pr-str x)))
+
+(defn try-from-edn
+  "Attempt to parse x as EDN, or return nil on failure"
+  [x]
+  #?(:clj (try (clojure.edn/read-string x) (catch Exception ex nil))
+     :cljs (try (cljs.reader/read-string x) (catch js/Error ex nil))))

--- a/src/framed/std/io.clj
+++ b/src/framed/std/io.clj
@@ -1,7 +1,7 @@
 (ns framed.std.io
   "I/O utility functions to complement clojure.java.io"
   (:require [clojure.java.io :as io])
-  (:import (java.io Closeable File DataInputStream DataOutputStream)
+  (:import (java.io File DataInputStream DataOutputStream)
            (org.apache.commons.io IOUtils)
            (java.nio.file Files StandardCopyOption))
   (:refer-clojure :exclude [spit]))
@@ -79,9 +79,3 @@
     (let [copy-opts (into-array [StandardCopyOption/ATOMIC_MOVE])]
       (Files/move (->Path src) (->Path dest) copy-opts)
       dest)))
-
-(defn close
-  "Close the given java.io.Closeable and return nil"
-  [^Closeable x]
-  (.close x)
-  nil)

--- a/src/framed/std/serialization.clj
+++ b/src/framed/std/serialization.clj
@@ -34,7 +34,7 @@
   (lazy-seq
     (if (seq coll)
       (cons (first coll) (closing-seq state (rest coll)))
-      (std.io/close state))))
+      (.close state))))
 
 (defn- consume-with
   "Return a lazy seq of values from repeatedly invoking f on input,
@@ -44,7 +44,7 @@
   (lazy-seq
     (try (cons (f input) (consume-with f input))
       (catch EOFException ex
-        (std.io/close input)))))
+        (.close input)))))
 
 ;;
 
@@ -271,7 +271,7 @@
   (lazy-seq
     (if (.hasNext adf)
       (cons (.next adf) (read-avro' adf))
-      (std.io/close adf))))
+      (.close adf))))
 
 (defn read-avro
   "Return a lazy seq of values from Avro-encoded File or InputStream
@@ -282,7 +282,7 @@
   (let [source
         (if (instance? InputStream x)
           (let [bs (IOUtils/toByteArray x)] ; Consumes entire stream!
-            (std.io/close x)
+            (.close x)
             bs)
           (.getPath (io/file x)))]
     (->> source

--- a/test/framed/std/core_test.clj
+++ b/test/framed/std/core_test.clj
@@ -46,6 +46,11 @@
     (is (= {:foo 1 :bar 2} (s/when-assoc-in m [:bar] 2)))
     (is (= {:foo 1 :bar {:norf 3}} (s/when-assoc-in m [:bar :norf] 3)))))
 
+(deftest test-when-assoc
+  (let [m {:foo 1}]
+    (is (= {:foo 1} (s/when-assoc m :bar nil)))
+    (is (= {:foo 1 :bar 2} (s/when-assoc m :bar 2)))))
+
 (deftest test-coll-wrap
   (is (= [2] (s/coll-wrap 2)))
   (is (= [1 2 3] (s/coll-wrap [1 2 3])))
@@ -57,3 +62,11 @@
         flipped-dissoc (s/flip dissoc)]
     (is (= {:bar 2} (flipped-dissoc :foo m)))
     (is (= {:bar 2} (s/flip dissoc :foo m)))))
+
+(deftest test-try-to-edn
+  (is (= "{:hello \"world\"}" (s/try-to-edn {:hello "world"})))
+  (is (= nil (s/try-to-edn nil))))
+
+(deftest test-from-edn
+  (is (= {:hello "world"} (s/try-from-edn "{:hello \"world\"}")))
+  (is (= nil (s/try-from-edn nil))))


### PR DESCRIPTION
- Add std.core/{try-to-edn, try-from-edn}
  - try-to-edn returns pr-str x if it is truthy, otherwise nil
  - try-from-edn tries to read an EDN string, and returns nil on failure
  - This gives common names to a set of previously disparate utilities
    elsewhere

- Add std.core/when-assoc
  - The vast majority of callers actually pass a single key, so this
    cleans things up.

- Remove `std.io/close`, and replace it with standard `.close` in
  std.serialization, which returns nil already