### PR TITLE
Add core/find

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.framed/std "0.2.0"
+(defproject io.framed/std "0.2.1"
   :description "A Clojure utility toolkit"
   :url "https://github.com/framed-data/std"
   :license {:name "Eclipse Public License"

--- a/src/framed/std/core.cljc
+++ b/src/framed/std/core.cljc
@@ -2,7 +2,15 @@
   "Utility functions to complement clojure.core"
   (:require #?(:clj [clojure.edn]
                :cljs [cljs.reader]))
-  (:refer-clojure :exclude [mapcat shuffle]))
+  (:refer-clojure :exclude [find mapcat shuffle]))
+
+(defn find
+  "Return the first value of x in coll that is logically true for (pred x)
+   Similar to clojure.core/some, but returns the item itself.
+
+   Ex: (find even? [1 1 1 3 4 5 6]) ; => 4"
+  [pred coll]
+  (first (filter pred coll)))
 
 (defn mapcat
   "Like clojure.core/mapcat over a single coll without object

--- a/test/framed/std/core_test.clj
+++ b/test/framed/std/core_test.clj
@@ -6,6 +6,10 @@
             [clojure.string :as string]
             [framed.std.core :as s]))
 
+(deftest test-find
+  (is (= 4 (s/find even? [1 1 1 1 3 3 3 3 4 5 5 6])))
+  (is (nil? (s/find even? [1 1 1 1 3 3 3]))))
+
 (defspec test-mapcat
   (prop/for-all [vs (gen/vector gen/string-alphanumeric)]
     (is (= (clojure.core/mapcat identity vs) (s/mapcat identity vs)))


### PR DESCRIPTION
`(clojure.core/some pred coll)` returns the first logically true value of
`(pred x)` for all x in coll. This makes it mostly useful for yes/no
questions:

```
user=> (some even? [1 1 1 2 2 3 3])
true
```

This can lead to subtle bugs if the actual intent is to find the first
matching *item*, for which there is no native clojure.core solution.
The new `(std.core/find pred coll)` finds the first item in coll
matching pred.

```
user=> (std/find even? [1 1 1 2 2 3 3])
2
```

This replaces calls to `(first (filter ...))` as well as erroneous calls
to `some`!

Naming is borrowed from http://underscorejs.org/#find