### PR TITLE
0.2.3: Revert core/single?

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.framed/std "0.2.2"
+(defproject io.framed/std "0.2.3"
   :description "A Clojure utility toolkit"
   :url "https://github.com/framed-data/std"
   :license {:name "Eclipse Public License"

--- a/src/framed/std/core.cljc
+++ b/src/framed/std/core.cljc
@@ -35,11 +35,6 @@
       (java.util.Collections/shuffle al rng)
       (clojure.lang.RT/vector (.toArray al)))))
 
-(defn single?
-  "Is coll of length 1?"
-  [coll]
-  (= 1 (count coll)))
-
 (defmacro map-from-keys
   "Given symbols, e.g. `(map-from-keys foo bar)`,
    return a map with those names as keyword keys, and those values:

--- a/test/framed/std/core_test.clj
+++ b/test/framed/std/core_test.clj
@@ -20,10 +20,6 @@
     (is (= [7 10 8 9 5 3 1 4 2 6]
            (std/shuffle (java.util.Random. 1) [1 2 3 4 5 6 7 8 9 10])))))
 
-(deftest test-single?
-  (is (std/single? [99]))
-  (is (not (std/single? [1 2 3 4]))))
-
 (deftest test-map-from-keys
   (let [foo 1
         bar 2]


### PR DESCRIPTION
I've had a sudden change of heart on this one after speculatively
putting it in place; it is a clean idiom in certain places, but I think
is a better fit for a `utils.clj` somewhere, because it doesn't quite
belong in every single place that `(= 1 (count coll))` is used.