### PR TITLE
Add support for move-and-replace

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.framed/std "0.2.3"
+(defproject io.framed/std "0.2.4"
   :description "A Clojure utility toolkit"
   :url "https://github.com/framed-data/std"
   :license {:name "Eclipse Public License"

--- a/src/framed/std/io.clj
+++ b/src/framed/std/io.clj
@@ -70,12 +70,17 @@
   (Files/createLink (->Path link) (->Path existing))
   link)
 
+(defn move'
+  "Atomically move file-like src to file-like dest and return dest."
+  [src dest]
+  (let [copy-opts (into-array [StandardCopyOption/ATOMIC_MOVE])]
+    (Files/move (->Path src) (->Path dest) copy-opts)
+    dest))
+
 (defn move
   "Atomically move file-like src to file-like dest and return dest.
    Throws error if dest already exists"
   [src dest]
   (if (.exists (io/file dest))
     (throw (IllegalArgumentException. "dest already exists"))
-    (let [copy-opts (into-array [StandardCopyOption/ATOMIC_MOVE])]
-      (Files/move (->Path src) (->Path dest) copy-opts)
-      dest)))
+    (move' src dest)))


### PR DESCRIPTION
Prior to this commit we had `std.io/move`, which only allowed for
move-and-throw-if-already-present.  This commit adds support for
move-and-replace-if-already-present, which allows us to gracefully
handle some of the exceptions we're seeing (multiple calls issued to
moved to the same destination, presumably by multiple racing threads,
and all but the first threads throwing).