### PR TITLE
Add std.core/def-

### DIFF
--- a/src/framed/std/core.cljc
+++ b/src/framed/std/core.cljc
@@ -4,6 +4,12 @@
                :cljs [cljs.reader]))
   (:refer-clojure :exclude [find mapcat shuffle]))
 
+(defmacro def-
+  "Like `clojure.core/def`, but attaches :private metadata.
+  Counterpart to `clojure.core/defn-`"
+  [sym init]
+  `(def ~(with-meta sym {:private true}) ~init))
+
 (defn find
   "Return the first value of x in coll that is logically true for (pred x)
    Similar to clojure.core/some, but returns the item itself.


### PR DESCRIPTION
`def-` is the missing counterpart to `defn-` for defining private
bindings, as opposed to strictly private functions.

There is much debate in community about the absence of def- [0][1], with
many pointing out the alternative: `(def ^{:private true} x 2)`.
However, `defn-` is quite pervasive in Clojure code, and so it seems
reasonable to offer `def-` as a library alternative, at least.

0: https://groups.google.com/forum/#!topic/clojure/O7xWh72zzuo
1:
https://groups.google.com/forum/#!msg/clojure/r_ym-h53f1E/y1S31QXNhcAJ