### PR TITLE
Add std.io/path-join

### DIFF
--- a/src/framed/std/io.clj
+++ b/src/framed/std/io.clj
@@ -2,6 +2,7 @@
   "I/O utility functions to complement clojure.java.io"
   (:require [clojure.java.io :as io])
   (:import (java.io File DataInputStream DataOutputStream)
+           java.nio.file.Paths
            (org.apache.commons.io IOUtils)
            (java.nio.file Files StandardCopyOption))
   (:refer-clojure :exclude [spit]))
@@ -9,6 +10,17 @@
 (def tmpdir
   "The system temporary directory"
   (System/getProperty "java.io.tmpdir"))
+
+(defn path-get
+  "Wrapper for java.nio.file.PathslPaths.get - converts a String
+   or seq of Strings to a Path using the system file separator"
+  [part & parts]
+  (Paths/get part (into-array String parts)))
+
+(defn path-join
+  "Join Strings into a String path using the system file separator"
+  [part & parts]
+  (str (apply path-get part parts)))
 
 (defn data-input-stream
   "Coerce argument to an open java.io.DataInputStream"

--- a/test/framed/std/io_test.clj
+++ b/test/framed/std/io_test.clj
@@ -1,14 +1,22 @@
 (ns framed.std.io-test
   (:require [clojure.test :refer :all]
             [clojure.java.io :as io]
-            [framed.std.io :as sio]))
+            [framed.std.io :as std.io]))
+
+(deftest test-path-get
+  (is (= "foo/bar/quux.txt" (str (std.io/path-get "foo" "bar" "quux.txt")))))
+
+(deftest test-path-join
+  (let [expected "foo/bar/quux.txt"]
+    (is (= expected (std.io/path-join "foo" "bar" "quux.txt")))
+    (is (= expected (std.io/path-join "foo/" "/bar" "quux.txt")))))
 
 (deftest test-stream-copy
   (let [contents "hello"
-        f1 (sio/spit (sio/tempfile) contents)
-        f2 (sio/tempfile)]
+        f1 (std.io/spit (std.io/tempfile) contents)
+        f2 (std.io/tempfile)]
     (is (empty? (slurp f2)))
     (with-open [istream (io/input-stream f1)
                 ostream (io/output-stream f2)]
-      (sio/stream-copy istream ostream))
+      (std.io/stream-copy istream ostream))
     (is (= contents (slurp f2)))))


### PR DESCRIPTION
This joins String parts into properly-formed filepaths using the system
separator.

Ex:

```
(std.io/path-join "foo/" "/bar" "quux.txt")
; => "foo/bar/quux.txt"
```