### PR TITLE
Add std.math/variance and std.math/std-dev

### DIFF
--- a/src/framed/std/math.clj
+++ b/src/framed/std/math.clj
@@ -78,3 +78,35 @@
   (if (> v max-val)
     max-val
     v))
+
+(defn- squared-deviations
+  "Return the set of squared deviations from items in `vs` to their mean"
+  [mean vs]
+  (map #(Math/pow (- % mean) 2) vs))
+
+(defn variance
+  "Compute the variance of `vs`. Divisor used is `n - ddof` where `ddof` represents
+   'delta degrees of freedom'. By default returns an unbiased estimate (ddof = 1)
+   For a biased estimate, set ddof = 0
+
+   See https://en.wikipedia.org/wiki/Bessel%27s_correction
+       https://en.wikipedia.org/wiki/Degrees_of_freedom_(statistics)"
+  ([vs]
+   (variance vs 1))
+  ([vs ddof]
+   {:pre [(number? ddof) (>= ddof 0)]}
+   (when (seq vs)
+     (/ (reduce + (squared-deviations (mean vs) vs))
+        (- (count vs) ddof)))))
+
+(defn std-dev
+  "Compute the standard deviation of `vs`. Divisor used is `n - ddof` where `ddof`
+   represents 'delta degrees of freedom'. By default returns an unbiased
+   estimate (ddof = 1). For a biased estimate, set ddof = 0
+
+   See https://en.wikipedia.org/wiki/Bessel%27s_correction
+       https://en.wikipedia.org/wiki/Degrees_of_freedom_(statistics)"
+  ([vs]
+   (std-dev vs 1))
+  ([vs ddof]
+   (some-> (variance vs ddof) Math/sqrt)))

--- a/test/framed/std/math_test.clj
+++ b/test/framed/std/math_test.clj
@@ -1,46 +1,72 @@
 (ns framed.std.math-test
   (:require [clojure.test :refer :all]
-            [framed.std.math :as m]
             [clojure.test.check :as tc]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
-            [clojure.test.check.clojure-test :refer [defspec]]))
+            [clojure.test.check.clojure-test :refer [defspec]]
+            [framed.std.math :as std.math]))
 
 (deftest test-nonzero?
-  (is (m/nonzero? -1))
-  (is (m/nonzero? 1))
-  (is (not (m/nonzero? 0)))
-  (is (not (m/nonzero? nil))))
+  (is (std.math/nonzero? -1))
+  (is (std.math/nonzero? 1))
+  (is (not (std.math/nonzero? 0)))
+  (is (not (std.math/nonzero? nil))))
 
 (deftest test-divide-some
-  (is (nil? (m/divide-some 1 0)))
-  (is (= 1/2 (m/divide-some 1 2)))
-  (is (thrown? AssertionError (m/divide-some nil 2)))
-  (is (thrown? AssertionError (m/divide-some 10 nil))))
+  (is (nil? (std.math/divide-some 1 0)))
+  (is (= 1/2 (std.math/divide-some 1 2)))
+  (is (thrown? AssertionError (std.math/divide-some nil 2)))
+  (is (thrown? AssertionError (std.math/divide-some 10 nil))))
 
 (defspec test-divide-some-generative
   (prop/for-all [numer gen/pos-int
                  denom gen/s-pos-int]
     (is (= (/ numer denom)
-           (m/divide-some numer denom)))))
+           (std.math/divide-some numer denom)))))
 
 (deftest test-round-bigdecimal
-  (is (= 0.33M (m/round-bigdecimal 2 0.3333333333M)))
-  (is (= 0.3M (m/round-bigdecimal 1 0.3333333333M))))
+  (is (= 0.33M (std.math/round-bigdecimal 2 0.3333333333M)))
+  (is (= 0.3M (std.math/round-bigdecimal 1 0.3333333333M))))
 
 (deftest test-round-places
-  (is (= 3.14 (m/round-places 2 3.14159))))
+  (is (= 3.14 (std.math/round-places 2 3.14159))))
 
 (deftest test-mean
-  (is (= 4.5 (double (m/mean (range 10)))))
-  (is (nil? (m/mean []))))
+  (is (= 4.5 (double (std.math/mean (range 10)))))
+  (is (nil? (std.math/mean []))))
 
 (deftest test-median
-  (is (= 4.5 (double (m/median (range 10)))))
-  (is (= 5 (m/median (range 11))))
-  (is (nil? (m/median []))))
+  (is (= 4.5 (double (std.math/median (range 10)))))
+  (is (= 5 (std.math/median (range 11))))
+  (is (nil? (std.math/median []))))
 
 (deftest test-mode
-  (is (= 2 (m/mode [1 2 3 2 3 2])))
-  (is (= [2 3] (m/mode [1 2 2 2 3 3 3])))
-  (is (nil? (m/mode [1 2 3 4 5]))))
+  (is (= 2 (std.math/mode [1 2 3 2 3 2])))
+  (is (= [2 3] (std.math/mode [1 2 2 2 3 3 3])))
+  (is (nil? (std.math/mode [1 2 3 4 5]))))
+
+(deftest test-variance
+  (let [vs '(2 4 4 4 5 5 7 9)]
+    (testing "1 ddof (default unbiased estimate)"
+      (is (= 4.57143 (->> (std.math/variance vs) (std.math/round-places 5))))
+      (is (= 4.57143 (->> (std.math/variance vs 1) (std.math/round-places 5)))))
+    (testing "0 ddof (biased estimate)"
+      (is (= 4.0 (std.math/variance vs 0))))
+    (is (= (std.math/variance vs) (std.math/variance (vec vs))) "It returns equal results for lists/vectors")
+    (is (nil? (std.math/variance [])) "It returns nil given an empty seq")
+    (is (nil? (std.math/variance nil)) "It returns nil given nil")
+    (is (thrown? AssertionError (std.math/variance vs nil)) "ddof must be integer")
+    (is (thrown? AssertionError (std.math/variance vs -1)) "ddof must be integer > 0")))
+
+(deftest test-std-dev
+  (let [vs '(2 4 4 4 5 5 7 9)]
+    (testing "1 ddof (default unbiased estimate)"
+      (is (= 2.13809 (->> (std.math/std-dev vs) (std.math/round-places 5))))
+      (is (= 2.13809 (->> (std.math/std-dev vs 1) (std.math/round-places 5)))))
+    (testing "0 ddof (biased estimate)"
+      (is (= 2.0 (std.math/std-dev vs 0))))
+    (is (= (std.math/std-dev vs) (std.math/std-dev (vec vs))) "It returns equal results for lists/vectors")
+    (is (nil? (std.math/std-dev [])) "It returns nil given an empty seq")
+    (is (nil? (std.math/std-dev nil)) "It returns nil given nil")
+    (is (thrown? AssertionError (std.math/std-dev vs nil)) "ddof must be integer")
+    (is (thrown? AssertionError (std.math/std-dev vs -1)) "ddof must be integer > 0")))


### PR DESCRIPTION
This adds functions for computing the variance and standard deviation of
a collection of values, respectively. By default, these functions return
unbiased estimates, using a divisor of `n - 1` instead of `n` (Bessel's
Correction [0]). This is parameterizable by the optional `ddof`
parameter ("delta degreees of freedom") as in NumPy [1], where the divisor is `n -
ddof`; ddof = 0 will result in a biased estimator.

0: https://en.wikipedia.org/wiki/Bessel%27s_correction

1:
https://docs.scipy.org/doc/numpy/reference/generated/numpy.var.html#numpy.var