### PR TITLE
Add std.core/fetch

### DIFF
--- a/src/framed/std/core.cljc
+++ b/src/framed/std/core.cljc
@@ -12,6 +12,12 @@
   [pred coll]
   (first (filter pred coll)))
 
+(defn fetch
+  "Like clojure.core/get, but raises an exception if no mapping is found for key"
+  [m k]
+  {:pre [(contains? m k)]}
+  (get m k))
+
 (defn mapcat
   "Like clojure.core/mapcat over a single coll without object
    reachability memory issues. This is especially useful when

--- a/test/framed/std/core_test.clj
+++ b/test/framed/std/core_test.clj
@@ -10,6 +10,11 @@
   (is (= 4 (std/find even? [1 1 1 1 3 3 3 3 4 5 5 6])))
   (is (nil? (std/find even? [1 1 1 1 3 3 3]))))
 
+(deftest test-find
+  (let [m {:foo 1}]
+    (is (= 1 (std/fetch m :foo)))
+    (is (thrown? AssertionError (std/fetch m :bar)))))
+
 (defspec test-mapcat
   (prop/for-all [vs (gen/vector gen/string-alphanumeric)]
     (is (= (clojure.core/mapcat identity vs) (std/mapcat identity vs)))


### PR DESCRIPTION
Like the Ruby function of the same name [0], `(std.core/fetch m k)`
retrieves the value mapped to a key, or raises if no mapping is found.
A similar concept is implemented in Tupelo called "grab" [1].

0: https://ruby-doc.org/core-2.2.0/Hash.html#method-i-fetch

1: http://cloojure.github.io/doc/tupelo/tupelo.core.html#var-grab