### PR TITLE
Use `reduce` instead of `apply` in `std.math/mean`

### DIFF
--- a/src/framed/std/math.clj
+++ b/src/framed/std/math.clj
@@ -35,7 +35,7 @@
   "Return the arithmetic mean of vs, or nil if empty"
   [vs]
   (when (seq vs)
-    (/ (apply + vs) (count vs))))
+    (/ (reduce + vs) (count vs))))
 
 (defn median
   "Return the median value of vs, or nil if empty"


### PR DESCRIPTION
This results in a 1.29x speedup on average (234ms for 100
runs on 1M longs compared to 304ms)