### PR TITLE
Add std.io/copy

### DIFF
--- a/src/framed/std/io.clj
+++ b/src/framed/std/io.clj
@@ -96,3 +96,13 @@
   (if (.exists (io/file dest))
     (throw (IllegalArgumentException. "dest already exists"))
     (move' src dest)))
+
+(defn copy
+  "Copy file-like src to file-like dest and return dest. Asserts dest is
+   not a non-empty file (see `clojure.java.io/copy` for unchecked copies)
+
+   Note: May theoretically race between dest-checking and copying"
+  [src dest]
+  {:pre [(not (nonempty-file? dest))]}
+  (io/copy (io/file src) (io/file dest))
+  dest)

--- a/test/framed/std/io_test.clj
+++ b/test/framed/std/io_test.clj
@@ -20,3 +20,15 @@
                 ostream (io/output-stream f2)]
       (std.io/stream-copy istream ostream))
     (is (= contents (slurp f2)))))
+
+(deftest test-copy
+  (let [contents "Hello,World"
+        src (std.io/spit (std.io/tempfile) contents)]
+    (testing "when dest does not exist"
+      (let [dest (std.io/copy src (std.io/tempfile))]
+        (is (= contents (slurp src)) "It does not modify src")
+        (is (not= (.getPath src) (.getPath dest)))
+        (is (= (slurp src) (slurp dest)))))
+    (testing "when dest exists and is non-empty"
+      (let [dest (std.io/spit (std.io/tempfile) "Already,Exists")]
+        (is (thrown? AssertionError (std.io/copy src dest)))))))


### PR DESCRIPTION
This adds `(std.io/copy src dest)` to copy one file-like to another, and
is the logical companion to `std.io/move`. It uses `clojure.java.io/copy` under the hood with the following additions:

- Raises an error if dest exists and is non-empty
- Returns dest, instead of being effectful-only