### PR TITLE
Parameterize `bufsize` in `std.io.stream-copy`, with default

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.framed/std "0.2.5"
+(defproject io.framed/std "0.2.6"
   :description "A Clojure utility toolkit"
   :url "https://github.com/framed-data/std"
   :license {:name "Eclipse Public License"

--- a/src/framed/std/io.clj
+++ b/src/framed/std/io.clj
@@ -32,14 +32,21 @@
   [ostream-like]
   (DataOutputStream. (io/output-stream ostream-like)))
 
+(def stream-copy-bufsize
+  "Buffer size to use for copying between streams, in bytes
+  See IOUtils.copyLarge https://commons.apache.org/proper/commons-io/javadocs/api-2.4/index.html"
+  64000000)
+
 (defn stream-copy
   "Copy from input stream to output stream.
    Does *not* close streams"
-  [input-stream output-stream]
-  (IOUtils/copyLarge
-    ^java.io.InputStream input-stream
-    ^java.io.OutputStream output-stream
-    (byte-array 64000000)))
+  ([input-stream output-stream]
+   (stream-copy stream-copy-bufsize input-stream output-stream))
+  ([bufsize input-stream output-stream]
+   (IOUtils/copyLarge
+     ^java.io.InputStream input-stream
+     ^java.io.OutputStream output-stream
+     (byte-array bufsize))))
 
 (defn spit
   "Like clojure.core/spit, but returns f"

--- a/test/framed/std/io_test.clj
+++ b/test/framed/std/io_test.clj
@@ -11,15 +11,23 @@
     (is (= expected (std.io/path-join "foo" "bar" "quux.txt")))
     (is (= expected (std.io/path-join "foo/" "/bar" "quux.txt")))))
 
-(deftest test-stream-copy
+(defn- test-stream-copy' [bufsize]
   (let [contents "hello"
         f1 (std.io/spit (std.io/tempfile) contents)
         f2 (std.io/tempfile)]
     (is (empty? (slurp f2)))
     (with-open [istream (io/input-stream f1)
                 ostream (io/output-stream f2)]
-      (std.io/stream-copy istream ostream))
+      (if bufsize
+        (std.io/stream-copy bufsize istream ostream)
+        (std.io/stream-copy istream ostream)))
     (is (= contents (slurp f2)))))
+
+(deftest test-stream-copy
+  (testing "with explicit bufsize"
+    (test-stream-copy' 2))
+  (testing "with default bufsize"
+    (test-stream-copy' nil)))
 
 (deftest test-copy
   (let [contents "Hello,World"


### PR DESCRIPTION
Previously this value was opaque / hardcoded, but exposing it can be
useful for callers doing calculations to constrain resource usage.
This adds a new arity to `std.io/stream-copy` for specifying the
bufsize, which defaults to the old value of 64MB.